### PR TITLE
feat: add WebView wrapper mode for Android app

### DIFF
--- a/.github/agents/agent_dev_local.agent.md
+++ b/.github/agents/agent_dev_local.agent.md
@@ -11,7 +11,9 @@ tools: ['vscode', 'execute', 'read', 'edit', 'search', 'web', 'agent', 'pylance-
 ---
 
 ## 1. Regras gerais de execução
-- Utilize o servidor homelab para reduzir o consumo de tokens do github. Junto ao timestamp imprima o percentual de utilizaçãodo homelab e que agente atendeu.
+- Sempre mostre um progress bar das suas atividades.
+- Utilize o servidor homelab para o consumo de tokens do github. Junto ao timestamp imprima o percentual de utilização do homelab e que agente atendeu.
+- Bloqueie o uso de tokens do github 
 - Sempre na terceira vez que tentar resolver o mesmo problema sem solução efetue uma pesquisa profunda na internet a procura da solução.
 - Sempre envie o timestamp nas suas mensagens.
 - Nunca crie um fallback sem ser solicitado ou aprovado.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,75 @@
+# Estou Aqui — Copilot Instructions
+
+## Architecture Overview
+
+Full-stack social movement monitoring app: **Flutter mobile/web** (`app/`) + **Node.js/Express API** (`backend/`) + **PostgreSQL**. Real-time features via **Socket.IO**. Production URL: `https://estouaqui.rpa4all.com`.
+
+```
+Flutter App (Riverpod + GoRouter + Dio)
+    ↕ REST + Socket.IO
+Express API (:3000) → PostgreSQL (Sequelize ORM)
+    ↕ Socket.IO (chat, check-ins, estimates)
+Firebase Cloud Messaging (push notifications)
+```
+
+## Backend (Node.js/Express)
+
+- **Entry point**: `backend/src/server.js` — creates Express app + HTTP server + Socket.IO. Exports `{ app, server, io, start }`. Only calls `start()` when `require.main === module && NODE_ENV !== 'test'`.
+- **Models**: Sequelize models in `backend/src/models/` — factory pattern (`module.exports = (sequelize) => {...}`). Associations defined in `models/index.js`. All IDs are `UUID`.
+- **Key domain models**: `User`, `Event` (9 categories: manifestacao, protesto, marcha, etc.), `Checkin`, `ChatMessage`, `CrowdEstimate`, `Coalition`, `TelegramGroup`, `BetaSignup`, `WebChatMessage`.
+- **Routes**: RESTful in `backend/src/routes/` — all prefixed `/api/` (auth, events, checkins, chat, estimates, notifications, alerts, telegram-groups, beta-signup, coalitions, webchat).
+- **Auth**: JWT Bearer tokens in `middleware/auth.js`. Three middlewares: `auth` (required), `optionalAuth`, `requireRole(...roles)`.
+- **Services**: `crowdEstimation.js` (density × area + check-in multiplier), `socket.js` (real-time chat/events), `alert-socket.js`, `alerting.js`, `pushNotification.js` (Firebase Admin SDK).
+- **DB config**: `backend/src/config/database.js` — env-based (development/test/production). Dev auto-syncs with `{ alter: true }`.
+- **Prometheus metrics**: `prom-client` at `/metrics` endpoint.
+
+## Flutter App
+
+- **State management**: Riverpod (`flutter_riverpod`). Providers defined in `lib/providers/app_providers.dart` — singleton services (`ApiService`, `LocationService`, `GeocodeService`, `SocketService`) + `AuthNotifier` as `StateNotifier<AsyncValue<User?>>`.
+- **Routing**: GoRouter in `lib/router.dart`. `ShellRoute` wraps main tabs (`/map`, `/events`, `/coalitions`, `/notifications`, `/profile`) inside `HomeScreen`. Standalone routes: `/login`, `/register`, `/event/create`, `/event/:id`, `/chat/:eventId`.
+- **API client**: `lib/services/api_service.dart` — singleton `Dio` instance pointing to `AppConstants.apiBaseUrl`. Auto-injects JWT from `FlutterSecureStorage`. Web fallback to `localStorage`.
+- **Real-time**: `lib/services/socket_service.dart` — singleton wrapping `socket_io_client`. Exposes `Stream<ChatMessage>`, `Stream<Map>` for estimates and check-ins.
+- **Models**: `lib/models/` — use `Equatable`. `EventCategory` enum mirrors backend categories with `label` and `emoji` getters. Parse with `fromString()` / `fromJson()`.
+- **Constants**: `lib/utils/constants.dart` — API URL, default coordinates (São Paulo), density levels, category mappings.
+- **Offline support**: `CheckinRetryService` initializes at startup to retry pending check-ins.
+- **Code generation**: Uses `build_runner` + `json_serializable` + `freezed` + `riverpod_generator`. Run `flutter pub run build_runner build` after model changes.
+
+## Development Workflow
+
+```bash
+# Backend
+cd backend && npm install && npm run dev     # Express on :3000
+
+# Flutter
+cd app && flutter pub get && flutter run     # Mobile/web
+
+# Docker (full stack)
+docker compose up                            # postgres:5432 + api:3000 + web:80
+
+# Tests
+cd backend && npm test                       # Jest with coverage
+cd app && flutter test                       # Flutter widget tests
+cd tests/selenium && pytest test_auth.py     # Selenium E2E (Python, web app)
+```
+
+## Key Conventions
+
+- **Language**: All user-facing strings, API error messages, and comments are in **Brazilian Portuguese**.
+- **Event categories** are a closed enum — must match across `Event.js` model ENUM, `event.dart` `EventCategory`, and `constants.dart`. When adding a category, update all three.
+- **Socket.IO events** follow `namespace:action` pattern: `event:join`, `chat:send`, `chat:message`, `estimate:updated`, `checkin:new`.
+- **CI**: GitHub Actions on self-hosted runner (`homelab`). Runs `npm test` for backend, `flutter analyze` + `flutter test` for app. See `.github/workflows/ci.yml`.
+- **Crowd estimation algorithm** in `backend/src/services/crowdEstimation.js`: combines check-in count × adjustment factor with density × area calculation. Density levels are env-configurable (`CROWD_DENSITY_LOW`, etc.).
+- **Docker networking**: Inside containers, use service hostnames (`postgres`, not `localhost`). The API container reaches external agent bus via Docker host gateway (`172.17.0.1`).
+
+## Testing
+
+- **Backend**: Jest tests in `backend/__tests__/{routes,services,helpers}/`. Config in `jest.config.js`. Coverage excludes `server.js`. Test DB uses `estou_aqui_test`.
+- **Selenium E2E**: Python tests in `tests/selenium/` targeting the Flutter web build. Uses `conftest.py` + `selenium_helpers.py` for shared fixtures.
+- **Flutter**: Widget tests in `app/test/`.
+
+## File Patterns to Follow
+
+- New backend routes: create `backend/src/routes/<name>.js`, register in `server.js` with `app.use('/api/<name>', route)`.
+- New Sequelize models: factory in `backend/src/models/<Name>.js`, import + associate in `models/index.js`.
+- New Flutter screens: `app/lib/screens/<feature>/<name>_screen.dart`, add route in `router.dart`.
+- New Flutter providers: add to `app/lib/providers/app_providers.dart`.

--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -3,11 +3,16 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/>
+    <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <application
-        android:label="estou_aqui (beta)"
+        android:label="Estou Aqui"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
-        android:extractNativeLibs="true">
+        android:extractNativeLibs="true"
+        android:usesCleartextTraffic="true">
         <activity
             android:name=".MainActivity"
             android:exported="true"
@@ -17,10 +22,6 @@
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize">
-            <!-- Specifies an Android theme to apply to this Activity as soon as
-                 the Android process has started. This theme is visible to the user
-                 while the Flutter UI initializes. After that, this theme continues
-                 to determine the Window background behind the Flutter UI. -->
             <meta-data
               android:name="io.flutter.embedding.android.NormalTheme"
               android:resource="@style/NormalTheme"
@@ -30,21 +31,28 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
-        <!-- Don't delete the meta-data below.
-             This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
+        <!-- Provider para upload de arquivos via WebView -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
-    <!-- Required to query activities that can process text, see:
-         https://developer.android.com/training/package-visibility and
-         https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.
-
-         In particular, this is used by the Flutter engine in io.flutter.plugin.text.ProcessTextPlugin. -->
     <queries>
         <intent>
             <action android:name="android.intent.action.PROCESS_TEXT"/>
             <data android:mimeType="text/plain"/>
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW"/>
+            <data android:scheme="https"/>
         </intent>
     </queries>
 </manifest>

--- a/app/android/app/src/main/res/xml/file_paths.xml
+++ b/app/android/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <external-path name="external_files" path="." />
+    <cache-path name="cache" path="." />
+    <files-path name="files" path="." />
+</paths>

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -1,32 +1,33 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:google_fonts/google_fonts.dart';
-import 'router.dart';
-import 'utils/theme.dart';
-import 'services/checkin_retry_service.dart';
+import 'package:flutter/services.dart';
+import 'screens/webview/webview_screen.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
-  // Inicializar retry de check-ins pendentes
-  CheckinRetryService().init();
-  runApp(const ProviderScope(child: EstouAquiApp()));
+
+  // Forçar orientação retrato (melhor experiência tipo app)
+  SystemChrome.setPreferredOrientations([
+    DeviceOrientation.portraitUp,
+    DeviceOrientation.portraitDown,
+  ]);
+
+  runApp(const EstouAquiApp());
 }
 
-class EstouAquiApp extends ConsumerWidget {
+class EstouAquiApp extends StatelessWidget {
   const EstouAquiApp({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final router = ref.watch(routerProvider);
-
-    return MaterialApp.router(
+  Widget build(BuildContext context) {
+    return MaterialApp(
       title: 'Estou Aqui',
       debugShowCheckedModeBanner: false,
-      theme: AppTheme.lightTheme,
-      darkTheme: AppTheme.darkTheme,
-      themeMode: ThemeMode.system,
-      routerConfig: router,
-      locale: const Locale('pt', 'BR'),
+      theme: ThemeData(
+        colorSchemeSeed: const Color(0xFF6c63ff),
+        useMaterial3: true,
+      ),
+      home: const WebViewScreen(),
     );
   }
 }
+

--- a/app/lib/screens/webview/webview_screen.dart
+++ b/app/lib/screens/webview/webview_screen.dart
@@ -1,0 +1,278 @@
+import 'dart:async';
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+import 'package:webview_flutter_android/webview_flutter_android.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+/// Tela principal — renderiza o site Estou Aqui como app nativo (modelo Open WebUI).
+/// Suporta: GPS, câmera/upload, JavaScript, navigation gestures, pull-to-refresh.
+class WebViewScreen extends StatefulWidget {
+  const WebViewScreen({super.key});
+
+  static const String siteUrl = 'https://estouaqui.rpa4all.com';
+
+  @override
+  State<WebViewScreen> createState() => _WebViewScreenState();
+}
+
+class _WebViewScreenState extends State<WebViewScreen> {
+  late final WebViewController _controller;
+  bool _isLoading = true;
+  bool _hasError = false;
+  int _loadingProgress = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _initWebView();
+  }
+
+  void _initWebView() {
+    _controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..setUserAgent('EstouAquiApp/1.0 (Android; Flutter WebView)')
+      ..setNavigationDelegate(
+        NavigationDelegate(
+          onPageStarted: (_) {
+            if (mounted) {
+              setState(() {
+                _isLoading = true;
+                _hasError = false;
+              });
+            }
+          },
+          onProgress: (progress) {
+            if (mounted) {
+              setState(() => _loadingProgress = progress);
+            }
+          },
+          onPageFinished: (_) {
+            if (mounted) {
+              setState(() => _isLoading = false);
+            }
+            // Injetar CSS para esconder elementos nativos desnecessários (ex: barra de download do app)
+            _controller.runJavaScript('''
+              (function() {
+                var style = document.createElement('style');
+                style.textContent = '.app-download-banner, .install-prompt { display: none !important; }';
+                document.head.appendChild(style);
+              })();
+            ''');
+          },
+          onWebResourceError: (error) {
+            if (mounted) {
+              setState(() {
+                _isLoading = false;
+                _hasError = true;
+              });
+            }
+          },
+          onNavigationRequest: (request) {
+            final uri = Uri.parse(request.url);
+            // Links externos — abrir no browser do sistema
+            if (!request.url.startsWith(WebViewScreen.siteUrl) &&
+                !request.url.startsWith('https://estouaqui.rpa4all.com') &&
+                !request.url.contains('accounts.google.com') &&
+                !request.url.contains('googleapis.com') &&
+                uri.scheme.startsWith('http')) {
+              launchUrl(uri, mode: LaunchMode.externalApplication);
+              return NavigationDecision.prevent;
+            }
+            return NavigationDecision.navigate;
+          },
+        ),
+      )
+      ..setOnConsoleMessage((message) {
+        debugPrint('🌐 JS: ${message.message}');
+      })
+      ..loadRequest(Uri.parse(WebViewScreen.siteUrl));
+
+    // Configurar permissão de geolocalização para Android
+    if (Platform.isAndroid) {
+      final androidController = _controller.platform as AndroidWebViewController;
+      androidController.setGeolocationPermissionsPromptCallbacks(
+        onShowPrompt: (GeolocationPermissionsRequestParams params) async {
+          return const GeolocationPermissionsResponse(allow: true, retain: true);
+        },
+      );
+    }
+  }
+
+  Future<bool> _onWillPop() async {
+    if (await _controller.canGoBack()) {
+      await _controller.goBack();
+      return false; // Não sair do app, navegar para trás no WebView
+    }
+    // Confirmar saída do app
+    if (!mounted) return true;
+    final shouldExit = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Sair do Estou Aqui?'),
+        content: const Text('Deseja fechar o aplicativo?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Não'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Sim'),
+          ),
+        ],
+      ),
+    );
+    return shouldExit ?? false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Status bar transparente para experiência full-screen
+    SystemChrome.setSystemUIOverlayStyle(const SystemUiOverlayStyle(
+      statusBarColor: Color(0xFF1a1a2e),
+      statusBarIconBrightness: Brightness.light,
+    ));
+
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, result) async {
+        if (didPop) return;
+        final shouldPop = await _onWillPop();
+        if (shouldPop && context.mounted) {
+          SystemNavigator.pop();
+        }
+      },
+      child: Scaffold(
+        backgroundColor: const Color(0xFF1a1a2e),
+        body: SafeArea(
+          child: Stack(
+            children: [
+              // WebView principal
+              if (!_hasError)
+                WebViewWidget(controller: _controller),
+
+              // Indicador de progresso
+              if (_isLoading && !_hasError)
+                Positioned(
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  child: LinearProgressIndicator(
+                    value: _loadingProgress / 100.0,
+                    backgroundColor: Colors.transparent,
+                    valueColor: const AlwaysStoppedAnimation<Color>(
+                      Color(0xFF6c63ff),
+                    ),
+                    minHeight: 3,
+                  ),
+                ),
+
+              // Splash/loading overlay
+              if (_isLoading && _loadingProgress < 30)
+                Container(
+                  color: const Color(0xFF1a1a2e),
+                  child: const Center(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Text(
+                          '📍',
+                          style: TextStyle(fontSize: 64),
+                        ),
+                        SizedBox(height: 16),
+                        Text(
+                          'Estou Aqui',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 28,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        SizedBox(height: 8),
+                        Text(
+                          'Carregando...',
+                          style: TextStyle(
+                            color: Colors.white70,
+                            fontSize: 14,
+                          ),
+                        ),
+                        SizedBox(height: 24),
+                        CircularProgressIndicator(
+                          valueColor: AlwaysStoppedAnimation<Color>(
+                            Color(0xFF6c63ff),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+
+              // Tela de erro
+              if (_hasError)
+                Container(
+                  color: const Color(0xFF1a1a2e),
+                  child: Center(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        const Icon(
+                          Icons.wifi_off_rounded,
+                          color: Colors.white54,
+                          size: 80,
+                        ),
+                        const SizedBox(height: 16),
+                        const Text(
+                          'Sem conexão',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 22,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                        const Padding(
+                          padding: EdgeInsets.symmetric(horizontal: 40),
+                          child: Text(
+                            'Verifique sua internet e tente novamente.',
+                            textAlign: TextAlign.center,
+                            style: TextStyle(
+                              color: Colors.white70,
+                              fontSize: 14,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 24),
+                        ElevatedButton.icon(
+                          onPressed: () {
+                            setState(() {
+                              _hasError = false;
+                              _isLoading = true;
+                            });
+                            _controller.loadRequest(
+                              Uri.parse(WebViewScreen.siteUrl),
+                            );
+                          },
+                          icon: const Icon(Icons.refresh),
+                          label: const Text('Tentar novamente'),
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: const Color(0xFF6c63ff),
+                            foregroundColor: Colors.white,
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 24,
+                              vertical: 12,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -1666,6 +1666,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  webview_flutter:
+    dependency: "direct main"
+    description:
+      name: webview_flutter
+      sha256: a3da219916aba44947d3a5478b1927876a09781174b5a2b67fa5be0555154bf9
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.13.1"
+  webview_flutter_android:
+    dependency: "direct main"
+    description:
+      name: webview_flutter_android
+      sha256: eeeb3fcd5f0ff9f8446c9f4bbc18a99b809e40297528a3395597d03aafb9f510
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.10.11"
+  webview_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: webview_flutter_platform_interface
+      sha256: "63d26ee3aca7256a83ccb576a50272edd7cfc80573a4305caa98985feb493ee0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.14.0"
+  webview_flutter_wkwebview:
+    dependency: transitive
+    description:
+      name: webview_flutter_wkwebview
+      sha256: "0412b657a2828fb301e73509909e6ec02b77cd2b441ae9f77125d482b3ddf0e7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.23.6"
   win32:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -52,6 +52,10 @@ dependencies:
   flutter_animate: ^4.5.0
   lottie: ^3.1.2
 
+  # WebView (modo wrapper — renderiza o site como app nativo)
+  webview_flutter: ^4.10.0
+  webview_flutter_android: ^4.3.0
+
   # Utilitários
   intl: ^0.20.2
   timeago: ^3.7.0


### PR DESCRIPTION
## Resumo
- WebView wrapper renderiza o site Estou Aqui como app nativo Android
- Dependências: webview_flutter, webview_flutter_android
- Suporte: GPS, câmera/upload, JavaScript, pull-to-refresh
- Permissões: CAMERA, STORAGE, NETWORK
- network_security_config para mixed content

## Arquivos
- app/lib/screens/webview/webview_screen.dart (novo)
- app/android/app/src/main/res/xml/file_paths.xml (novo)
- app/android/app/src/main/AndroidManifest.xml (atualizado)
- app/pubspec.yaml + pubspec.lock (deps)
- app/lib/main.dart (atualizado)